### PR TITLE
Fixes Issue-108 - restorecon should detect path

### DIFF
--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -132,7 +132,8 @@ define selinux::fcontext (
   if $restorecond {
     exec { "restorecond ${resource_name}":
       path        => '/bin:/sbin:/usr/bin:/usr/sbin',
-      command     => "restorecon ${restorecond_resurse_private}${restorecond_path_private}",
+      command     => "restorecon ${restorecond_resurse_private}\"${restorecond_path_private}\"",
+      onlyif      => "test -e \"${restorecond_path_private}\"",
       refreshonly => true,
       subscribe   => Exec[$resource_name],
     }


### PR DESCRIPTION
Here is a "one line" fix to test for the existence of e path before trying to restorecon. I also added double quotes because it seemed like a "good idea" (paths with spaces)

Let me know if you want me to rebase this against my #105 fix or keep branching from "master"
